### PR TITLE
feat(blogptbr): add remark frontmatter plugins

### DIFF
--- a/apps/blogptbr/next.config.js
+++ b/apps/blogptbr/next.config.js
@@ -1,7 +1,10 @@
 const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
   options: {
-    remarkPlugins: [],
+    remarkPlugins: [
+      require('remark-frontmatter'),
+      require('remark-mdx-frontmatter'),
+    ],
     rehypePlugins: [],
   },
 });

--- a/apps/blogptbr/package.json
+++ b/apps/blogptbr/package.json
@@ -20,7 +20,9 @@
     "react-dom": "^18",
     "@mdx-js/loader": "^3.0.0",
     "@mdx-js/react": "^3.0.0",
-    "remark-gfm": "^4.0.0"
+    "remark-gfm": "^4.0.0",
+    "remark-frontmatter": "^4.0.0",
+    "remark-mdx-frontmatter": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## Summary
- configure MDX to parse front matter
- add remark-frontmatter and remark-mdx-frontmatter dependencies

## Testing
- `pnpm install --filter blogptbr` *(fails: GET https://registry.npmjs.org/remark-frontmatter: Forbidden - 403)*
- `pnpm --filter blogptbr build` *(fails: Cannot find module 'remark-frontmatter')*

------
https://chatgpt.com/codex/tasks/task_e_689b79c0aecc832a8475c5fb5d220148