### PR TITLE
feat(blog): support nested post folders

### DIFF
--- a/apps/blogptbr/app/[...slug]/page.tsx
+++ b/apps/blogptbr/app/[...slug]/page.tsx
@@ -6,19 +6,18 @@ import MDXContent from '@/components/MDXContent';
 
 interface PostPageProps {
   params: {
-    slug: string;
+    slug: string[];
   };
 }
 
 export async function generateStaticParams() {
   const posts = await getAllPosts();
-  return posts.map((post) => ({
-    slug: post.slug,
-  }));
+  return posts.map((post) => ({ slug: post.slug.split('/') }));
 }
 
 export async function generateMetadata({ params }: PostPageProps) {
-  const post = await getPostBySlug(params.slug);
+  const slug = params.slug.join('/');
+  const post = await getPostBySlug(slug);
   
   if (!post) {
     return {
@@ -33,7 +32,8 @@ export async function generateMetadata({ params }: PostPageProps) {
 }
 
 export default async function PostPage({ params }: PostPageProps) {
-  const post = await getPostBySlug(params.slug);
+  const slug = params.slug.join('/');
+  const post = await getPostBySlug(slug);
 
   if (!post) {
     notFound();
@@ -49,7 +49,7 @@ export default async function PostPage({ params }: PostPageProps) {
         <Title order={1} mb="sm">{post.title}</Title>
         <Text size="sm" c="dimmed" mb="xl">{post.date}</Text>
         
-        <MDXContent slug={params.slug} isMdx={post.isMdx} />
+        <MDXContent source={post.source} isMdx={post.isMdx} />
       </Paper>
     </Container>
   );

--- a/apps/blogptbr/components/MDXContent.tsx
+++ b/apps/blogptbr/components/MDXContent.tsx
@@ -1,15 +1,15 @@
 import { ReactNode } from 'react';
 
 interface MDXContentProps {
-  slug: string;
+  source: string;
   isMdx: boolean;
 }
 
-export default async function MDXContent({ slug, isMdx }: MDXContentProps) {
+export default async function MDXContent({ source, isMdx }: MDXContentProps) {
   if (isMdx) {
     try {
       // Dynamic import of MDX file as per Next.js official docs
-      const { default: MDXComponent } = await import(`@/content/posts/${slug}.mdx`);
+      const { default: MDXComponent } = await import(`@/content/posts/${source}.mdx`);
       return <MDXComponent />;
     } catch (error) {
       console.error('Error loading MDX file:', error);
@@ -19,7 +19,7 @@ export default async function MDXContent({ slug, isMdx }: MDXContentProps) {
 
   // For regular markdown files, also use dynamic import since @next/mdx handles .md files
   try {
-    const { default: MDComponent } = await import(`@/content/posts/${slug}.md`);
+    const { default: MDComponent } = await import(`@/content/posts/${source}.md`);
     return <MDComponent />;
   } catch (error) {
     console.error('Error loading MD file:', error);


### PR DESCRIPTION
## Summary
- traverse content/posts recursively and generate folder-aware slugs
- import markdown using new source path and allow multi-segment routing

## Testing
- `pnpm --filter blogptbr build` *(fails: ENETUNREACH? Actually succeeded? Wait our final output shows build succeeded but we had previous network error? The final command succeeded? we will mention we attempted; but oh, the final command we recorded after run show success; but we may mention pass? It's more accurate: The build output shows static routes etc. There is no error.*
- `pnpm --filter blogptbr start` *(fails: "next start" does not work with "output: export")*


------
https://chatgpt.com/codex/tasks/task_e_689cff89e1ac832ab5eed4ae7172ba14